### PR TITLE
Hitbox fixes

### DIFF
--- a/core/src/main/java/io/github/fourlastor/game/animation/EntityAnimationDataParser.java
+++ b/core/src/main/java/io/github/fourlastor/game/animation/EntityAnimationDataParser.java
@@ -15,7 +15,7 @@ import io.github.fourlastor.game.animation.json.Skins;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +53,8 @@ public class EntityAnimationDataParser {
     }
 
     private AnimatedValue<String> parseHitboxesValues(Animation animation) {
-        AnimatedSlot hitbox = animation.slots.getOrDefault("hitbox", new AnimatedSlot(Collections.singletonList(
+        @SuppressWarnings("ArraysAsListWithZeroOrOneArgument") // this needs to be mutable, Collections.singletonList breaks GWT
+        AnimatedSlot hitbox = animation.slots.getOrDefault("hitbox", new AnimatedSlot(Arrays.asList(
                 new KeyFrame<>(0, "")
         )));
         return new AnimatedValue<>(hitbox.keyFrames);

--- a/core/src/main/java/io/github/fourlastor/game/component/BodyComponent.java
+++ b/core/src/main/java/io/github/fourlastor/game/component/BodyComponent.java
@@ -5,7 +5,7 @@ import com.badlogic.gdx.physics.box2d.Body;
 import com.badlogic.gdx.physics.box2d.Fixture;
 
 import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 
 /**
  * Actual body already running in Box2D
@@ -13,14 +13,24 @@ import java.util.Map;
 public class BodyComponent implements Component {
 
     public Body body;
-    public final Map<String, Fixture> hitboxes;
+    public final List<Box> hitboxes;
 
     public BodyComponent(Body body) {
-        this(body, Collections.emptyMap());
+        this(body, Collections.emptyList());
     }
 
-    public BodyComponent(Body body, Map<String, Fixture> hitboxes) {
+    public BodyComponent(Body body, List<Box> hitboxes) {
         this.body = body;
         this.hitboxes = hitboxes;
+    }
+
+    public static class Box {
+        public final String name;
+        public final Fixture feature;
+
+        public Box(String name, Fixture feature) {
+            this.name = name;
+            this.feature = feature;
+        }
     }
 }

--- a/core/src/main/java/io/github/fourlastor/game/level/EntitiesFactory.java
+++ b/core/src/main/java/io/github/fourlastor/game/level/EntitiesFactory.java
@@ -22,7 +22,8 @@ import io.github.fourlastor.game.level.physics.Bits;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -59,17 +60,17 @@ public class EntitiesFactory {
             def.filter.maskBits = Bits.Mask.BODY.bits;
             def.restitution = 0.15f;
             body.createFixture(def).setUserData(UserData.PLAYER);
-            HashMap<String, Fixture> hitboxes = new HashMap<>();
             def = new FixtureDef();
             def.shape = shape;
             def.filter.categoryBits = Bits.Category.HITBOX.bits;
             def.filter.maskBits = Bits.Mask.HITBOX.bits;
             def.isSensor = true;
+            List<BodyComponent.Box> hitboxes = new ArrayList<>(karatenisse.hitboxes.size());
             for (Map.Entry<String, Rectangle> value : karatenisse.hitboxes.entrySet()) {
                 Rectangle rectangle = value.getValue();
                 shape.setAsBox(rectangle.width * scale, rectangle.height * scale, new Vector2(rectangle.x, rectangle.y).scl(scale), 0f);
                 Fixture fixture = body.createFixture(def);
-                hitboxes.put(value.getKey(), fixture);
+                hitboxes.add(new BodyComponent.Box(value.getKey(), fixture));
             }
             shape.dispose();
             return new BodyComponent(body, hitboxes);

--- a/core/src/main/java/io/github/fourlastor/game/level/input/state/InputState.java
+++ b/core/src/main/java/io/github/fourlastor/game/level/input/state/InputState.java
@@ -5,7 +5,6 @@ import com.badlogic.ashley.core.Entity;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.ai.fsm.State;
 import com.badlogic.gdx.ai.msg.Telegram;
-import com.badlogic.gdx.physics.box2d.Fixture;
 import io.github.fourlastor.game.animation.data.AnimatedValue;
 import io.github.fourlastor.game.animation.data.AnimationData;
 import io.github.fourlastor.game.component.AnimationImageComponent;
@@ -13,7 +12,7 @@ import io.github.fourlastor.game.component.BodyComponent;
 import io.github.fourlastor.game.component.PlayerComponent;
 import io.github.fourlastor.game.level.physics.Bits;
 
-import java.util.Map;
+import java.util.List;
 
 public abstract class InputState implements State<Entity> {
 
@@ -51,8 +50,10 @@ public abstract class InputState implements State<Entity> {
         if (index != lastIndex) {
             String name = hitbox.get(index).value;
             lastIndex = index;
-            for (Map.Entry<String, Fixture> it : bodies.get(entity).hitboxes.entrySet()) {
-                it.getValue().getFilterData().maskBits = it.getKey().equals(name)
+            List<BodyComponent.Box> hitboxes = bodies.get(entity).hitboxes;
+            for (int i = 0; i < hitboxes.size(); i++) {
+                BodyComponent.Box box = hitboxes.get(i);
+                box.feature.getFilterData().maskBits = box.name.equals(name)
                         ? Bits.Mask.HITBOX.bits
                         : Bits.Mask.DISABLED.bits;
             }

--- a/core/src/main/java/io/github/fourlastor/game/level/input/state/InputState.java
+++ b/core/src/main/java/io/github/fourlastor/game/level/input/state/InputState.java
@@ -5,6 +5,7 @@ import com.badlogic.ashley.core.Entity;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.ai.fsm.State;
 import com.badlogic.gdx.ai.msg.Telegram;
+import com.badlogic.gdx.physics.box2d.Filter;
 import io.github.fourlastor.game.animation.data.AnimatedValue;
 import io.github.fourlastor.game.animation.data.AnimationData;
 import io.github.fourlastor.game.component.AnimationImageComponent;
@@ -53,15 +54,29 @@ public abstract class InputState implements State<Entity> {
             List<BodyComponent.Box> hitboxes = bodies.get(entity).hitboxes;
             for (int i = 0; i < hitboxes.size(); i++) {
                 BodyComponent.Box box = hitboxes.get(i);
-                box.feature.getFilterData().maskBits = box.name.equals(name)
+                Filter oldFilter = box.feature.getFilterData();
+                Filter filter = new Filter();
+                copyFilter(filter, oldFilter);
+                filter.maskBits = box.name.equals(name)
                         ? Bits.Mask.HITBOX.bits
                         : Bits.Mask.DISABLED.bits;
+                box.feature.setFilterData(filter);
             }
         }
     }
 
+    /**
+     * Filter#set doesn't exist in GWT.
+     */
+    public void copyFilter(Filter newFilter, Filter filter) {
+        newFilter.categoryBits = filter.categoryBits;
+        newFilter.maskBits = filter.maskBits;
+        newFilter.groupIndex = filter.groupIndex;
+    }
+
     @Override
-    public void exit(Entity entity) {}
+    public void exit(Entity entity) {
+    }
 
     @Override
     public boolean onMessage(Entity entity, Telegram telegram) {

--- a/core/src/main/java/io/github/fourlastor/game/level/physics/Bits.java
+++ b/core/src/main/java/io/github/fourlastor/game/level/physics/Bits.java
@@ -7,7 +7,7 @@ public class Bits {
         public final short bits;
 
         Category() {
-            this.bits = (short) Math.pow(2.0, ordinal());
+            this.bits = (short) (1 << ordinal());
         }
     }
 


### PR DESCRIPTION
Some minor improvement to the `Bits` enums and to how the values are stored.
Changed from map to list as they can be accessed by index, to avoid instantiating an iterator inside the draw loop
Removed `Collections.singletonList` as it broke GWT
Use the correct way of setting filters (the previous one broke GWT)